### PR TITLE
✨ Reward Increase 

### DIFF
--- a/BlazorGameSpike/BlazorGameSpike.Client/State/GameState.cs
+++ b/BlazorGameSpike/BlazorGameSpike.Client/State/GameState.cs
@@ -55,7 +55,7 @@ public class GameState
         if (EnemyHealth <= 0)
         {
             DefeatEnemy();
-            AddCurrency(1 + (EnemiesDefeated / 10));
+            AddCurrency(1 + (EnemiesDefeated / 100));
         }
     }
     

--- a/BlazorGameSpike/BlazorGameSpike.Client/State/GameState.cs
+++ b/BlazorGameSpike/BlazorGameSpike.Client/State/GameState.cs
@@ -55,7 +55,7 @@ public class GameState
         if (EnemyHealth <= 0)
         {
             DefeatEnemy();
-            AddCurrency(1);
+            AddCurrency(1 + (EnemiesDefeated / 10));
         }
     }
     

--- a/BlazorGameSpike/BlazorGameSpike.Client/State/GameState.cs
+++ b/BlazorGameSpike/BlazorGameSpike.Client/State/GameState.cs
@@ -52,7 +52,7 @@ public class GameState
         EnemyHealth -= amount;
         InvokeStateChange();
 
-        if (EnemyHealth < 0)
+        if (EnemyHealth <= 0)
         {
             DefeatEnemy();
             AddCurrency(1);


### PR DESCRIPTION
# Pain
At the moment, users only gain 1 `currency` per kill.

# What's changed?

We now increase the currency by `1 + (EnemiesDefeated / 10)` to passively increase how much the player gains over the course of play.

Also fixes a bug where an enemy will only die when `< 0` HP.
